### PR TITLE
Set the api version to 1.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.openmrs.module</groupId>
 	<artifactId>mergeconcepts</artifactId>
-	<version>0.0.x</version>
+	<version>1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Merge Concepts Module</name>
 	<description>MeIUpdates concept id references</description>


### PR DESCRIPTION
The subpackages rely on a version of 1.0-SNAPSHOT, but the current
version is set to 0.0.x.  This commit just updates the version to match
